### PR TITLE
Add DataCleanr SaaS web application

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,200 @@
+import os
+from io import BytesIO
+from datetime import datetime
+
+from flask import (Flask, render_template, redirect, url_for, request, flash,
+                   send_file)
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import (LoginManager, UserMixin, login_user, login_required,
+                         logout_user, current_user)
+from werkzeug.security import generate_password_hash, check_password_hash
+import pandas as pd
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'super-secret-key'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///datacleanr.db'
+app.config['UPLOAD_FOLDER'] = 'uploads'
+
+# database setup
+db = SQLAlchemy(app)
+login_manager = LoginManager()
+login_manager.login_view = 'login'
+login_manager.init_app(app)
+
+# in-memory store for processed data
+processed_data = {}
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(150), unique=True)
+    password = db.Column(db.String(150))
+
+
+class CleaningHistory(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    original_filename = db.Column(db.String(150))
+    cleaned_filename = db.Column(db.String(150))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+
+def clean_dataframe(df, remove_duplicates=True, fill_missing=True,
+                    standardize=True, normalize=True):
+    """Clean dataframe according to options."""
+    cleaned = df.copy()
+    if remove_duplicates:
+        cleaned = cleaned.drop_duplicates()
+    if fill_missing:
+        for col in cleaned.columns:
+            if pd.api.types.is_numeric_dtype(cleaned[col]):
+                cleaned[col].fillna(cleaned[col].median(), inplace=True)
+                cleaned[col] = pd.to_numeric(cleaned[col], errors='coerce').astype(float)
+            else:
+                cleaned[col].fillna('N/A', inplace=True)
+    if standardize:
+        for col in cleaned.columns:
+            if 'date' in col.lower() or pd.api.types.is_datetime64_any_dtype(cleaned[col]):
+                cleaned[col] = pd.to_datetime(cleaned[col], errors='coerce').dt.strftime('%Y-%m-%d')
+            elif pd.api.types.is_numeric_dtype(cleaned[col]):
+                cleaned[col] = pd.to_numeric(cleaned[col], errors='coerce').astype(float)
+    if normalize:
+        for col in cleaned.columns:
+            if pd.api.types.is_object_dtype(cleaned[col]):
+                cleaned[col] = cleaned[col].astype(str).str.title()
+    return cleaned
+
+
+@app.route('/')
+@login_required
+def dashboard():
+    return render_template('dashboard.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        email = request.form.get('email')
+        password = request.form.get('password')
+        user = User.query.filter_by(email=email).first()
+        if user and check_password_hash(user.password, password):
+            login_user(user)
+            return redirect(url_for('dashboard'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+
+@app.route('/signup', methods=['GET', 'POST'])
+def signup():
+    if request.method == 'POST':
+        email = request.form.get('email')
+        password = request.form.get('password')
+        if User.query.filter_by(email=email).first():
+            flash('Email already exists')
+            return redirect(url_for('signup'))
+        new_user = User(email=email, password=generate_password_hash(password))
+        db.session.add(new_user)
+        db.session.commit()
+        flash('Account created, please login')
+        return redirect(url_for('login'))
+    return render_template('signup.html')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('login'))
+
+
+@app.route('/upload', methods=['GET', 'POST'])
+@login_required
+def upload():
+    if request.method == 'POST':
+        file = request.files.get('data_file')
+        if not file:
+            flash('No file selected')
+            return redirect(request.url)
+        try:
+            if file.filename.endswith('.csv'):
+                df = pd.read_csv(file)
+            else:
+                df = pd.read_excel(file)
+        except Exception:
+            flash('Could not read file')
+            return redirect(request.url)
+        # free tier limit
+        if df.shape[0] > 1000:
+            flash('Dataset exceeds free tier limit (1000 rows)')
+            return redirect(request.url)
+        auto = 'auto_clean' in request.form
+        options = {
+            'remove_duplicates': auto or 'remove_duplicates' in request.form,
+            'fill_missing': auto or 'fill_missing' in request.form,
+            'standardize': auto or 'standardize' in request.form,
+            'normalize': auto or 'normalize' in request.form,
+        }
+        cleaned = clean_dataframe(df, **options)
+        buffer = BytesIO()
+        cleaned.to_csv(buffer, index=False)
+        buffer.seek(0)
+        cleaned_name = f"cleaned_{file.filename}"
+        history = CleaningHistory(user_id=current_user.id,
+                                  original_filename=file.filename,
+                                  cleaned_filename=cleaned_name)
+        db.session.add(history)
+        db.session.commit()
+        processed_data[current_user.id] = {
+            'original': df.head(20).to_html(classes='data'),
+            'cleaned': cleaned.head(20).to_html(classes='data'),
+            'download': buffer.getvalue(),
+            'download_name': cleaned_name,
+        }
+        return redirect(url_for('result'))
+    return render_template('upload.html')
+
+
+@app.route('/result')
+@login_required
+def result():
+    data = processed_data.get(current_user.id)
+    if not data:
+        return redirect(url_for('dashboard'))
+    return render_template('result.html', original=data['original'], cleaned=data['cleaned'])
+
+
+@app.route('/download')
+@login_required
+def download():
+    data = processed_data.get(current_user.id)
+    if not data:
+        return redirect(url_for('dashboard'))
+    return send_file(BytesIO(data['download']), as_attachment=True,
+                     download_name=data['download_name'], mimetype='text/csv')
+
+
+@app.route('/history')
+@login_required
+def history():
+    records = (CleaningHistory.query
+               .filter_by(user_id=current_user.id)
+               .order_by(CleaningHistory.timestamp.desc()).all())
+    return render_template('history.html', records=records)
+
+
+@app.route('/account')
+@login_required
+def account():
+    return render_template('account.html', user=current_user)
+
+
+if __name__ == '__main__':
+    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True, host='0.0.0.0')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+Flask-Login
+Flask-SQLAlchemy
+pandas
+openpyxl

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,35 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #fff;
+    color: #333;
+}
+.sidebar {
+    width: 200px;
+    float: left;
+    height: 100vh;
+    background-color: #f0f8ff;
+    padding: 20px;
+}
+.sidebar a {
+    display: block;
+    color: #1e90ff;
+    margin-bottom: 10px;
+    text-decoration: none;
+}
+.content {
+    margin-left: 220px;
+    padding: 20px;
+}
+table.data {
+    border-collapse: collapse;
+}
+table.data th, table.data td {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+button, input[type=submit] {
+    background-color: #1e90ff;
+    color: white;
+    border: none;
+    padding: 10px;
+}

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Account</h3>
+<p>Email: {{ user.email }}</p>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+    <title>DataCleanr</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="sidebar">
+    <h2>DataCleanr</h2>
+    {% if current_user.is_authenticated %}
+    <a href="{{ url_for('dashboard') }}">Dashboard</a>
+    <a href="{{ url_for('upload') }}">Upload</a>
+    <a href="{{ url_for('history') }}">History</a>
+    <a href="{{ url_for('account') }}">Account</a>
+    <a href="{{ url_for('logout') }}">Logout</a>
+    {% else %}
+    <a href="{{ url_for('login') }}">Login</a>
+    <a href="{{ url_for('signup') }}">Signup</a>
+    {% endif %}
+</div>
+<div class="content">
+    {% with messages = get_flashed_messages() %}
+    {% if messages %}
+    <ul>
+        {% for message in messages %}
+        <li>{{ message }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Welcome, {{ current_user.email }}</h3>
+<p>Select an option from the sidebar.</p>
+{% endblock %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Past Cleanings</h3>
+<table class="data">
+<tr><th>Original</th><th>Cleaned</th><th>Date</th></tr>
+{% for r in records %}
+<tr>
+    <td>{{ r.original_filename }}</td>
+    <td>{{ r.cleaned_filename }}</td>
+    <td>{{ r.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
+</tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Login</h3>
+<form method="post">
+    <input type="email" name="email" placeholder="Email" required><br>
+    <input type="password" name="password" placeholder="Password" required><br>
+    <input type="submit" value="Login">
+</form>
+<p>No account? <a href="{{ url_for('signup') }}">Sign up</a></p>
+{% endblock %}

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Cleaned Result Preview</h3>
+<h4>Original</h4>
+{{ original|safe }}
+<h4>Cleaned</h4>
+{{ cleaned|safe }}
+<br>
+<a href="{{ url_for('download') }}">Download Cleaned File</a>
+{% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Sign Up</h3>
+<form method="post">
+    <input type="email" name="email" placeholder="Email" required><br>
+    <input type="password" name="password" placeholder="Password" required><br>
+    <input type="submit" value="Sign Up">
+</form>
+<p>Have an account? <a href="{{ url_for('login') }}">Login</a></p>
+{% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h3>Upload Data</h3>
+<form method="post" enctype="multipart/form-data">
+    <input type="file" name="data_file" required><br>
+    <label><input type="checkbox" name="remove_duplicates"> Remove duplicates</label><br>
+    <label><input type="checkbox" name="fill_missing"> Fill missing values</label><br>
+    <label><input type="checkbox" name="standardize"> Standardize formats</label><br>
+    <label><input type="checkbox" name="normalize"> Normalize text case</label><br>
+    <input type="submit" name="clean" value="Clean Selected">
+    <input type="submit" name="auto_clean" value="Auto Clean">
+</form>
+{% endblock %}

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+from app import clean_dataframe
+
+def test_clean_dataframe():
+    df = pd.DataFrame({
+        'A': [1, 1, None],
+        'B': ['foo', 'foo', 'bar'],
+        'Date': ['2021/01/01', '2021/01/01', '2021.01.01']
+    })
+    cleaned = clean_dataframe(df)
+    assert cleaned.shape[0] == 2  # duplicates removed
+    assert cleaned['A'].notnull().all()
+    assert cleaned['B'].iloc[1] == 'Bar'
+    assert cleaned['Date'].iloc[0] == '2021-01-01'


### PR DESCRIPTION
## Summary
- build DataCleanr Flask app with email/password auth and dashboard
- allow CSV/Excel uploads, auto-cleaning of data, and download of cleaned file
- show cleaning history and enforce free tier row limit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1a7f233ec832e90db39f8b0ba6624